### PR TITLE
chan os.Signal should be buffered

### DIFF
--- a/pkg/shutdown/shutdown.go
+++ b/pkg/shutdown/shutdown.go
@@ -11,7 +11,7 @@ func init() {
 	signal.Notify(signals, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 }
 
-var signals = make(chan os.Signal)
+var signals = make(chan os.Signal, 1)
 
 func Chan() <-chan struct{} {
 	shutdown := make(chan struct{})


### PR DESCRIPTION
shutdown uses an unbuffered channel for os.Signal.  Recommendation is to use a buffered channel, otherwise, you may miss a signal.